### PR TITLE
Removed unused namespaces and 7.1 compatibility 

### DIFF
--- a/TeamSpeak3/Adapter/Blacklist.php
+++ b/TeamSpeak3/Adapter/Blacklist.php
@@ -27,7 +27,6 @@
 
 namespace TeamSpeak3\Adapter;
 
-use TeamSpeak3\Adapter\AbstractAdapter;
 use TeamSpeak3\Helper\Profiler;
 use TeamSpeak3\Helper\Signal;
 use TeamSpeak3\Transport\AbstractTransport;

--- a/TeamSpeak3/Helper/StringHelper.php
+++ b/TeamSpeak3/Helper/StringHelper.php
@@ -32,7 +32,6 @@ use \Iterator;
 use \Countable;
 use TeamSpeak3\TeamSpeak3;
 use TeamSpeak3\Ts3Exception;
-use TeamSpeak3\Helper\Signal;
 
 /**
  * @class String

--- a/TeamSpeak3/Node/Channel.php
+++ b/TeamSpeak3/Node/Channel.php
@@ -453,8 +453,6 @@ class Channel extends AbstractNode
     public function delete($force = false)
     {
         $this->getParent()->channelDelete($this->getId(), $force);
-
-        unset($this);
     }
 
     /**

--- a/TeamSpeak3/Node/Channelgroup.php
+++ b/TeamSpeak3/Node/Channelgroup.php
@@ -77,8 +77,6 @@ class Channelgroup extends AbstractNode
     public function delete($force = false)
     {
         $this->getParent()->channelGroupDelete($this->getId(), $force);
-
-        unset($this);
     }
 
     /**

--- a/TeamSpeak3/Node/Server.php
+++ b/TeamSpeak3/Node/Server.php
@@ -2326,8 +2326,6 @@ class Server extends AbstractNode
     public function delete()
     {
         $this->getParent()->serverDelete($this->getId());
-
-        unset($this);
     }
 
     /**

--- a/TeamSpeak3/Node/Servergroup.php
+++ b/TeamSpeak3/Node/Servergroup.php
@@ -78,8 +78,6 @@ class Servergroup extends AbstractNode
     public function delete($force = false)
     {
         $this->getParent()->serverGroupDelete($this->getId(), $force);
-
-        unset($this);
     }
 
     /**

--- a/TeamSpeak3/TeamSpeak3.php
+++ b/TeamSpeak3/TeamSpeak3.php
@@ -28,12 +28,18 @@
 namespace TeamSpeak3;
 
 use TeamSpeak3\Adapter\AbstractAdapter;
+use TeamSpeak3\Adapter\Blacklist;
+use TeamSpeak3\Adapter\FileTransfer;
 use TeamSpeak3\Adapter\ServerQuery;
+use TeamSpeak3\Adapter\TSDNS;
+use TeamSpeak3\Adapter\Update;
 use TeamSpeak3\Helper\Uri;
 use TeamSpeak3\Helper\StringHelper;
 use TeamSpeak3\Helper\Profiler;
 use TeamSpeak3\Node\AbstractNode;
 use TeamSpeak3\Node\Server;
+
+
 use \LogicException;
 
 /**

--- a/TeamSpeak3/TeamSpeak3.php
+++ b/TeamSpeak3/TeamSpeak3.php
@@ -27,24 +27,13 @@
 
 namespace TeamSpeak3;
 
-use TeamSpeak3\Ts3Exception;
 use TeamSpeak3\Adapter\AbstractAdapter;
-use TeamSpeak3\Adapter\Blacklist;
-use TeamSpeak3\Adapter\FileTransfer;
 use TeamSpeak3\Adapter\ServerQuery;
-use TeamSpeak3\Adapter\TSDNS;
-use TeamSpeak3\Adapter\Update;
 use TeamSpeak3\Helper\Uri;
 use TeamSpeak3\Helper\StringHelper;
 use TeamSpeak3\Helper\Profiler;
 use TeamSpeak3\Node\AbstractNode;
-use TeamSpeak3\Node\Channel;
-use TeamSpeak3\Node\Channelgroup;
-use TeamSpeak3\Node\Client;
-use TeamSpeak3\Node\Host;
 use TeamSpeak3\Node\Server;
-use TeamSpeak3\Node\Servergroup;
-
 use \LogicException;
 
 /**


### PR DESCRIPTION
By reading the code in Teamspeak3\Teamspeak3 I dont think the adapters are needed because 
```$adapter = self::getAdapterName($uri->getScheme());``` returns the full class namespace anyway. But I havn't tested if it would work without the namespace so I put them aback in. I may add a better way of loading the classes in a later pull request.