### PR TITLE
Replace TeamSpeak3_Helper_String with StringHelper

### DIFF
--- a/TeamSpeak3/Node/Channel.php
+++ b/TeamSpeak3/Node/Channel.php
@@ -393,7 +393,7 @@ class Channel extends AbstractNode
     /**
      * Downloads and returns the channels icon file content.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function iconDownload()
     {

--- a/TeamSpeak3/Node/Channelgroup.php
+++ b/TeamSpeak3/Node/Channelgroup.php
@@ -176,7 +176,7 @@ class Channelgroup extends AbstractNode
      * @param  integer $cid
      * @param  string $description
      * @param  string $customset
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function privilegeKeyCreate($cid, $description = null, $customset = null)
     {
@@ -215,7 +215,7 @@ class Channelgroup extends AbstractNode
     /**
      * Downloads and returns the channel groups icon file content.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function iconDownload()
     {

--- a/TeamSpeak3/Node/Client.php
+++ b/TeamSpeak3/Node/Client.php
@@ -27,6 +27,7 @@
 
 namespace TeamSpeak3\Node;
 
+use TeamSpeak3\Helper\StringHelper;
 use TeamSpeak3\TeamSpeak3;
 
 /**
@@ -280,17 +281,17 @@ class Client extends AbstractNode
     /**
      * Returns the possible name of the clients avatar.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function avatarGetName()
     {
-        return new TeamSpeak3_Helper_String("/avatar_" . $this["client_base64HashClientUID"]);
+        return new StringHelper("/avatar_" . $this["client_base64HashClientUID"]);
     }
 
     /**
      * Downloads and returns the clients avatar file content.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function avatarDownload()
     {
@@ -345,7 +346,7 @@ class Client extends AbstractNode
     /**
      * Downloads and returns the clients icon file content.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function iconDownload()
     {

--- a/TeamSpeak3/Node/Server.php
+++ b/TeamSpeak3/Node/Server.php
@@ -1345,7 +1345,7 @@ class Server extends AbstractNode
             foreach ($perms as $permsid => $perm) {
                 if (in_array($permsid, array_keys($profiles[$sgid]))) {
                     $profiles[$sgid][$permsid] = $perm["permvalue"];
-                } elseif (TeamSpeak3_Helper_String::factory($permsid)->startsWith("i_needed_modify_power_")) {
+                } elseif (StringHelper::factory($permsid)->startsWith("i_needed_modify_power_")) {
                     if (!$grant || $perm["permvalue"] > $grant) {
                         continue;
                     }
@@ -1595,7 +1595,7 @@ class Server extends AbstractNode
      * Restores the default permission settings on the virtual server and returns a new initial
      * administrator privilege key.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function permReset()
     {
@@ -1759,7 +1759,7 @@ class Server extends AbstractNode
     /**
      * Downloads and returns the servers icon file content.
      *
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function iconDownload()
     {
@@ -1908,15 +1908,15 @@ class Server extends AbstractNode
     {
         switch ($mode) {
             case TeamSpeak3::SNAPSHOT_BASE64:
-                $data = TeamSpeak3_Helper_String::fromBase64($data);
+                $data = StringHelper::fromBase64($data);
                 break;
 
             case TeamSpeak3::SNAPSHOT_HEXDEC:
-                $data = TeamSpeak3_Helper_String::fromHex($data);
+                $data = StringHelper::fromHex($data);
                 break;
 
             default:
-                $data = TeamSpeak3_Helper_String::factory($data);
+                $data = StringHelper::factory($data);
                 break;
         }
 
@@ -2030,7 +2030,7 @@ class Server extends AbstractNode
      * @param  integer $id2
      * @param  string $description
      * @param  string $customset
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function privilegeKeyCreate(
         $type = TeamSpeak3::TOKEN_SERVERGROUP,
@@ -2385,7 +2385,7 @@ class Server extends AbstractNode
      * will be auto-generated.
      *
      * @param  string $username
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function selfUpdateLogin($username)
     {

--- a/TeamSpeak3/Transport/UDP.php
+++ b/TeamSpeak3/Transport/UDP.php
@@ -89,7 +89,7 @@ class UDP extends AbstractTransport
      *
      * @param  integer $length
      * @throws Ts3Exception
-     * @return TeamSpeak3_Helper_String
+     * @return StringHelper
      */
     public function read($length = 4096)
     {


### PR DESCRIPTION
Fix the class resolution bug with `TeamSpeak3_Helper_String` by using the correct class and `use TeamSpeak3\Helper\StringHelper` where it is missing. 