### PR TITLE
Fixed numeric message not being converted to StringHelper

### DIFF
--- a/TeamSpeak3/Adapter/ServerQuery/Reply.php
+++ b/TeamSpeak3/Adapter/ServerQuery/Reply.php
@@ -179,8 +179,10 @@ class Reply
                 } else {
                     list($ident, $value) = $pair->split(TeamSpeak3::SEPARATOR_PAIR, 2);
 
-                    $array[$i][$ident->toString()] = $value->isInt() ? $value->toInt() : (!func_num_args(
-                    ) ? $value->unescape() : $value);
+                    if($ident == 'msg')
+                        $array[$i][$ident->toString()] = new StringHelper($value->unescape());
+                    else
+                        $array[$i][$ident->toString()] = $value->isInt() ? $value->toInt() : (!func_num_args() ? $value->unescape() : $value);
                 }
             }
         }


### PR DESCRIPTION
Message 1 would cause code to crash, but with commit it will no longer
happen.
Screenshots: From http://i.imgur.com/rAOaIcl.png to
http://i.imgur.com/nePdUpt.png